### PR TITLE
feature: added ability to convert to OpenMath quads

### DIFF
--- a/src/OmRdfParser.ts
+++ b/src/OmRdfParser.ts
@@ -1,4 +1,4 @@
-import { QuadsAndPrefixes } from "Quand";
+import { QuadsAndPrefixes } from "./QuadsAndPrefixes";
 import { PrefixedFormula } from "./Formula";
 import { FormulaResult } from "./FormulaResult";
 import { allFromOpenMath, fromOpenMath } from "./fromOpenMath";

--- a/src/OmRdfParser.ts
+++ b/src/OmRdfParser.ts
@@ -1,7 +1,8 @@
+import { QuadsAndPrefixes } from "Quand";
 import { PrefixedFormula } from "./Formula";
 import { FormulaResult } from "./FormulaResult";
 import { allFromOpenMath, fromOpenMath } from "./fromOpenMath";
-import { replaceIris, resolvePrefixes, toOpenMath } from "./toOpenMath";
+import { replaceIris, resolvePrefixes, toOpenMath, toOpenMathQuadsAndPrefixes } from "./toOpenMath";
 
 /**
  * A parser that allows converting between string and RDF representation of mathematical formulas
@@ -28,6 +29,16 @@ export class OmRdfParser {
 	 */
 	fromOpenMath(rdfString: string, rootApplicationIri: string): Promise<FormulaResult> {
 		return fromOpenMath(rdfString, rootApplicationIri);
+	}
+
+	/**
+	 * Converts a mathematical formula in plain string representation to its OpenMath RDF quads and prefixes representation.
+	 * 
+	 * @param {PrefixedFormula | string} formula - In the simplest case, this is a string representation of a formula without any references to ontological entities, e.g., `x + y <= 2`. For such cases, blank nodes are created representing x and y. Alternatively, you can provide a PrefixedFormula object to include prefixes for IRIs.
+	 * @returns {QuadsAndPrefixes} - The OpenMath RDF quads and corresponding prefixes of the input formula.
+	 */
+	toOpenMathQuadsAndPrefixes(formula: PrefixedFormula | string): QuadsAndPrefixes {
+		return toOpenMathQuadsAndPrefixes(formula);
 	}
 
 	/**

--- a/src/QuadsAndPrefixes.ts
+++ b/src/QuadsAndPrefixes.ts
@@ -1,0 +1,6 @@
+import { Quad } from "n3";
+
+export interface QuadsAndPrefixes {
+  quads: Quad[];
+  prefixes: Record<string, string>;
+}

--- a/src/toOpenMath.ts
+++ b/src/toOpenMath.ts
@@ -3,7 +3,7 @@ import { OperatorDictionary } from './OperatorDictionary';
 import { BlankNode, DataFactory, NamedNode, Quad, Store, Term, Writer } from 'n3';
 import { PrefixedFormula } from './Formula';
 import { IriVariableDictionary } from './IriVariableMap';
-import { QuadsAndPrefixes } from 'Quand';
+import { QuadsAndPrefixes } from './QuadsAndPrefixes';
 const { literal, blankNode, namedNode } = DataFactory;
 
 // Define base IRI


### PR DESCRIPTION
Hi! 

I really like this project! Thank you!

I've created new method `.toOpenMathQuadsAndPrefixes()` it allows to fetch the quads and then manipulte them later in the code.

PS
I think that `package-lock.json` should be also commited. Why it isn't? It is also  good option to have a `.prettierrc` file 😁, I had some problems with formatting. Some time ago I was using this [tutorial](https://echobind.com/post/integrating-prettier-eslint-airbnb-style-guide-in-vscode) / [here](https://www.digitalocean.com/community/tutorials/how-to-format-code-with-prettier-in-visual-studio-code) is other one.